### PR TITLE
Update 4.0 to 4.0.0-rc.2

### DIFF
--- a/3.1/jessie/Dockerfile
+++ b/3.1/jessie/Dockerfile
@@ -10,16 +10,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -36,7 +32,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -47,7 +42,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/3.2/jessie/Dockerfile
+++ b/3.2/jessie/Dockerfile
@@ -10,16 +10,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -36,7 +32,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -47,7 +42,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/3.3/jessie/Dockerfile
+++ b/3.3/jessie/Dockerfile
@@ -10,16 +10,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -36,7 +32,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -47,7 +42,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/3.4/jessie/Dockerfile
+++ b/3.4/jessie/Dockerfile
@@ -10,16 +10,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -36,7 +32,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -47,7 +42,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/4.0/alpine3.6/Dockerfile
+++ b/4.0/alpine3.6/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH /usr/local/bin:$PATH
 RUN apk add --no-cache ca-certificates
 
 ENV NEKO_VERSION 2.2.0
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 
 RUN set -ex \
@@ -45,7 +45,7 @@ RUN set -ex \
 	&& ninja \
 	&& ninja install \
 	\
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apk add --no-cache --virtual .build-deps \
 		pcre-dev \

--- a/4.0/alpine3.7/Dockerfile
+++ b/4.0/alpine3.7/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH /usr/local/bin:$PATH
 RUN apk add --no-cache ca-certificates
 
 ENV NEKO_VERSION 2.2.0
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 
 RUN set -ex \
@@ -45,7 +45,7 @@ RUN set -ex \
 	&& ninja \
 	&& ninja install \
 	\
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apk add --no-cache --virtual .build-deps \
 		pcre-dev \

--- a/4.0/alpine3.8/Dockerfile
+++ b/4.0/alpine3.8/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH /usr/local/bin:$PATH
 RUN apk add --no-cache ca-certificates
 
 ENV NEKO_VERSION 2.2.0
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 
 RUN set -ex \
@@ -45,7 +45,7 @@ RUN set -ex \
 	&& ninja \
 	&& ninja install \
 	\
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apk add --no-cache --virtual .build-deps \
 		pcre-dev \

--- a/4.0/alpine3.9/Dockerfile
+++ b/4.0/alpine3.9/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH /usr/local/bin:$PATH
 RUN apk add --no-cache ca-certificates
 
 ENV NEKO_VERSION 2.2.0
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 
 RUN set -ex \
@@ -45,7 +45,7 @@ RUN set -ex \
 	&& ninja \
 	&& ninja install \
 	\
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apk add --no-cache --virtual .haxe-build-deps \
 		pcre-dev \

--- a/4.0/alpine3.9/Dockerfile
+++ b/4.0/alpine3.9/Dockerfile
@@ -66,7 +66,8 @@ RUN set -ex \
 	\
 	&& opam init --disable-sandboxing \
 	&& eval $(opam env) \
-	&& make opam_install \
+	&& opam pin add haxe . --no-action \
+	&& opam install haxe --deps-only --yes \
 	&& make all tools \
 	\
 	&& mkdir -p /usr/local/bin \

--- a/4.0/jessie/Dockerfile
+++ b/4.0/jessie/Dockerfile
@@ -55,7 +55,7 @@ RUN set -ex \
 	&& rm -rf /usr/src/neko ~/.cache
 
 # install haxe
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 RUN set -ex \
 	&& buildDeps=' \
@@ -69,7 +69,7 @@ RUN set -ex \
 		unzip \
 		\
 	' \
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/4.0/jessie/Dockerfile
+++ b/4.0/jessie/Dockerfile
@@ -10,16 +10,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -36,7 +32,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -47,7 +42,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/4.0/onbuild/Dockerfile
+++ b/4.0/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM haxe:4.0.0-rc.1
+FROM haxe:4.0.0-rc.2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/4.0/stretch/Dockerfile
+++ b/4.0/stretch/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 	&& rm -rf /usr/src/neko ~/.cache
 
 # install haxe
-ENV HAXE_VERSION 4.0.0-rc.1
+ENV HAXE_VERSION 4.0.0-rc.2
 ENV HAXE_STD_PATH /usr/local/share/haxe/std
 RUN set -ex \
 	&& buildDeps=' \
@@ -73,7 +73,7 @@ RUN set -ex \
 		unzip \
 		\
 	' \
-	&& git clone --recursive --depth 1 --branch 4.0.0-rc.1 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
+	&& git clone --recursive --depth 1 --branch 4.0.0-rc.2 "https://github.com/HaxeFoundation/haxe.git" /usr/src/haxe \
 	&& cd /usr/src/haxe \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	\

--- a/4.0/windowsservercore/Dockerfile
+++ b/4.0/windowsservercore/Dockerfile
@@ -50,14 +50,14 @@ RUN $url = 'https://github.com/HaxeFoundation/neko/releases/download/v2-2-0/neko
 	Write-Host 'Complete.';
 
 # install haxe
-ENV HAXE_VERSION 4.0.0-rc.1
-RUN $url = 'https://github.com/HaxeFoundation/haxe/releases/download/4.0.0-rc.1/haxe-4.0.0-rc.1-win64.zip'; \
+ENV HAXE_VERSION 4.0.0-rc.2
+RUN $url = 'https://github.com/HaxeFoundation/haxe/releases/download/4.0.0-rc.2/haxe-4.0.0-rc.2-win64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile haxe.zip; \
 	\
-	Write-Host 'Verifying sha256 (ef533d35e628cf8bb28753ef25c242ecc439173bfb2abaddcad9eee690d0b9c0) ...'; \
-	if ((Get-FileHash haxe.zip -Algorithm sha256).Hash -ne 'ef533d35e628cf8bb28753ef25c242ecc439173bfb2abaddcad9eee690d0b9c0') { \
+	Write-Host 'Verifying sha256 (0921a930870c5d0a8d4faa9e19e10e7023e6914527e11212772424a435f20542) ...'; \
+	if ((Get-FileHash haxe.zip -Algorithm sha256).Hash -ne '0921a930870c5d0a8d4faa9e19e10e7023e6914527e11212772424a435f20542') { \
 		Write-Host 'FAILED!'; \
 		exit 1; \
 	}; \

--- a/Dockerfile-alpine3.9.template
+++ b/Dockerfile-alpine3.9.template
@@ -66,7 +66,8 @@ RUN set -ex \
 	::if USE_OPAM::\
 	&& opam init --disable-sandboxing \
 	&& eval $(opam env) \
-	&& make opam_install \
+	&& opam pin add haxe . --no-action \
+	&& opam install haxe --deps-only --yes \
 	&& make all tools \
 	::else::\
 	&& OCAMLPARAM=safe-string=0,_ make all tools \

--- a/Dockerfile-jessie.template
+++ b/Dockerfile-jessie.template
@@ -6,16 +6,12 @@ FROM buildpack-deps:jessie-scm
 ENV PATH /usr/local/bin:$PATH
 
 # runtime dependencies
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgc1c2 \
 		zlib1g \
 		libpcre3 \
 		libmariadb2 \
 		libsqlite3-0 \
-		libmbedcrypto0 \
-		libmbedtls10 \
-		libmbedx509-0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install neko, which is a dependency of haxelib
@@ -32,7 +28,6 @@ RUN set -ex \
 		apache2-dev \
 		libmariadb-client-lgpl-dev-compat \
 		libsqlite3-dev \
-		libmbedtls-dev \
 		libgtk2.0-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
@@ -43,7 +38,7 @@ RUN set -ex \
 	&& tar -xC /usr/src/neko --strip-components=1 -f neko.tar.gz \
 	&& rm neko.tar.gz \
 	&& cd /usr/src/neko \
-	&& cmake -DRELOCATABLE=OFF . \
+	&& cmake -DRELOCATABLE=OFF -DSTATIC_DEPS=MbedTLS . \
 	&& make \
 	&& make install \
 	\

--- a/Update.hx
+++ b/Update.hx
@@ -49,10 +49,10 @@ class Update {
 			"opam": false
 		},
 		{
-			"version": "4.0.0-rc.1",
-			"tag": "4.0.0-rc.1",
+			"version": "4.0.0-rc.2",
+			"tag": "4.0.0-rc.2",
 			"win64": true,
-			"sha256": {"win": "ef533d35e628cf8bb28753ef25c242ecc439173bfb2abaddcad9eee690d0b9c0"},
+			"sha256": {"win": "0921a930870c5d0a8d4faa9e19e10e7023e6914527e11212772424a435f20542"},
 			"exclude": [],
 			"opam": true
 		},


### PR DESCRIPTION
Downloaded the windows release from github, did that to update the checksum:
```
$ sha256sum haxe-4.0.0-rc.2-win64.zip 
0921a930870c5d0a8d4faa9e19e10e7023e6914527e11212772424a435f20542  haxe-4.0.0-rc.2-win64.zip
```

(checked against rc.1 to ensure I was doing the same thing)